### PR TITLE
is.gd updated to use https

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ var shorteners = {
 	},
 
 	'is.gd': function(longurl, params, callback) {
-		var host = 'http://is.gd/';
+		var host = 'https://is.gd/';
 		if ( 'host' in params && ['is.gd', 'v.gd'].indexOf(params.host) >= 0 ) {
 			host = 'http://' + params.host + '/';
 			delete params.host;


### PR DESCRIPTION
As of early May 2016, `is.gd` only works with [https](http://is.gd/news.php).

This update adds the single char `s`.
